### PR TITLE
Support input_re and output_sub parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,25 @@ EUC-JP, which could feasibly cause particular problems.
 
 Better to just use the system one for now.  If somebody wants to submit a pure-
 python implementation that functions, I'll gladly integrate it as a separate
-msgfmtpy plugin in the same repository.
+`msgfmtpy` plugin in the same repository.
 
-Depends on the `locales` and `destinations` plugin config parameters,
-specifying where the source locale files and destination compiled locale files
-should be found.
+# Config parameters
+
+* `locales`: The location of the source `.po` files.
+
+* `destination`: The location of the destination `.mo` files.  They will be put
+  into this location in the same structure as the source tree relative to the
+  `locales` path.
+
+* `pathsub_regex` (optional): An input regex to match against source files for
+  name changes.
+
+* `pathsub_replace` (required if `pathsub_regex` is present): An replacement
+  pattern to use for name changes.
 
 # Copyright
 
-This plugin is Copyright 2023 Absolute Performance, Inc.
+This plugin is Copyright 2023 Absolute Performance, Inc. with contributions by
+[Adrián Chaves](https://github.com/Gallaecio).
 
 MIT licensed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'hatch-msgfmt'
-version = '1.1.4'
+version = '1.1.6'
 description = 'Msgfmt build hook, replacing all po with mo in build'
 license = {text = 'MIT'}
 readme = 'README.md'

--- a/src/hatch_msgfmt/plugin.py
+++ b/src/hatch_msgfmt/plugin.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any, Mapping
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from pathlib import Path
@@ -18,13 +19,18 @@ class MsgfmtBuildHook(BuildHookInterface):
         root = Path(self.root)
         locales = root / Path(self.config['locales'])
         destination = Path(self.config['destination'])
+        input_re = self.config['input_re']
+        output_sub = self.config['output_sub']
 
         for po in locales.glob('**/*.po'):
-            dest = destination / po.relative_to(locales)
+            mo = po.relative_to(locales)
+            if input_re:
+                mo = Path(re.sub(input_re, output_sub, str(mo)))
+            dest = str(destination / mo)
 
             output = UnopenedTemporaryFile(suffix='.mo')
 
             run(['msgfmt', '-o', str(output), str(po)], check=True, stdin=DEVNULL)
 
             self.__files.append(output)
-            build_data['force_include'][str(output)] = str(dest)
+            build_data['force_include'][str(output)] = dest

--- a/src/hatch_msgfmt/plugin.py
+++ b/src/hatch_msgfmt/plugin.py
@@ -19,12 +19,14 @@ class MsgfmtBuildHook(BuildHookInterface):
         root = Path(self.root)
         locales = root / Path(self.config['locales'])
         destination = Path(self.config['destination'])
-        input_re = self.config['input_re']
-        output_sub = self.config['output_sub']
+        input_re = self.config.get('input_re')
+        output_sub = self.config.get('output_sub')
 
         for po in locales.glob('**/*.po'):
-            mo = po.relative_to(locales)
+            mo = po.relative_to(locales).with_suffix('.mo')
             if input_re:
+                if not isinstance(output_sub, str):
+                    raise TypeError('output_sub must be a string')
                 mo = Path(re.sub(input_re, output_sub, str(mo)))
             dest = str(destination / mo)
 


### PR DESCRIPTION
What would you think about allowing to customize the output path based on the input path through regular expressions?

For example, with this change, I can have a repository with:

```
po/
    gl.po
```

And get a wheel with:

```
foo/
    locale/
        gl/
            LC_MESSAGES/
                foo.mo
```

By using something like:

```
locales = "po"
destination = "foo/locale"
input_re = "(.*)\\.po"
output_sub = "\\1/LC_MESSAGES/foo.mo"
```

If it sounds good to you, please let me know, and I’ll update the README accordingly so you can consider this request for merging.

I also wonder if we can use better names for the 2 new options. I considered `input_pattern` and `output_repl` in line with the matching `re.sub` parameters, but I was not sure.